### PR TITLE
Throw instead of updating fake 'this'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You construct your tests in a spec-like manner, grouping a bunch of tests togeth
 When compared to a spec, you can see your current running instance of `Passable` as your describe function, and each `pass` is equivalent to a single it.
 
 The `pass` function is a single test inside of the group of tests. It accepts the name of the test, description of the success condition, and the actual test function.
-If the test function returns true, the test has passed. If not, it is considered as failed.
+If you explicitly return true, or if your enforce function passed correctly, it is assumed that the pass is `true`.
 
 You could perform multiple 'passes' on the same data object. If you do so, it is recommended to use the same name for all these passes, as the results for all tests under the same name will be grouped together.
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "passable",
-    "version": "5.5.0",
+    "version": "5.5.1",
     "description": "Isomorphic Data Model Validations",
     "main": "./dist/Passable.min.js",
     "author": "Evyatar <evyatar.a@fiverr.com>",
@@ -9,6 +9,10 @@
         "build": "WEBPACK_ENV=build webpack",
         "build:watch": "webpack --watch",
         "dev": "WEBPACK_ENV=dev webpack --progress --colors --watch",
+        "test:custom": "mocha --compilers js:babel-core/register --colors -w './src/**/*custom.spec.js'",
+        "test:global_custom": "mocha --compilers js:babel-core/register --colors -w './src/spec/passable.api.global-custom.spec.js'",
+        "test:enforce": "mocha --compilers js:babel-core/register --colors -w './src/enforce/spec.js'",
+        "test:pass_runner": "mocha --compilers js:babel-core/register --colors -w './src/pass_runner/spec.js'",
         "test:watch": "mocha --compilers js:babel-core/register --colors -w './src/**/*spec.js'",
         "test": "mocha --compilers js:babel-core/register --colors './src/**/*spec.js'",
         "eslint": "eslint -c .eslintrc './src/**/*.js'; exit 0"

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -24,14 +24,7 @@ class Passable {
         return this.res;
     }
 
-    enforce(value) {
-        const e = enforce.bind(this.currentPass);
-        return e(value, this.custom);
-    }
-
     pass(fieldName, statement, ...args) {
-
-        this.currentPass = {};
 
         if (this.specific.length && this.specific.indexOf(fieldName) === -1) {
             this.res.skipped.push(fieldName);
@@ -42,7 +35,7 @@ class Passable {
 
         // callback is always the last argument
         const callback = args.pop(),
-            isValid = passRunner.call(this.currentPass, callback);
+            isValid = passRunner(callback);
 
         if (!isValid) {
             const severity = args[0] || FAIL;
@@ -52,8 +45,11 @@ class Passable {
         }
 
         this.bumpCounters(fieldName);
-        this.currentPass = {};
         return isValid;
+    }
+
+    enforce(value) {
+        return enforce(value, this.custom);
     }
 
     bumpCounters(fieldName) {

--- a/src/enforce/index.js
+++ b/src/enforce/index.js
@@ -9,11 +9,9 @@ function isInvalid(valid) {
     return !isUntested(valid) && valid === false;
 }
 
-function enforce(value, custom) {
-    const self = this || {};
-    custom = custom || {};
-
-    const registered = Object.assign({}, rules, custom);
+function enforce(value, custom = {}) {
+    const self = {},
+        allRules = Object.assign({}, rules, custom);
 
     self.anyOf = (tests) => run('anyOf', tests);
     self.allOf = (tests) => run('allOf', tests);
@@ -25,12 +23,17 @@ function enforce(value, custom) {
             return self;
         }
 
-        self.valid = runners[group](value, tests, registered);
+        self.valid = runners[group](value, tests, allRules);
+
+        if (self.valid !== true) {
+            throw new Error(`${group} - ${value} - invalid`);
+        }
+
         return self;
     }
 
     function fin() {
-        return self.valid;
+        return !!self.valid;
     }
 
     return self;

--- a/src/enforce/spec.js
+++ b/src/enforce/spec.js
@@ -14,34 +14,43 @@ describe('Test Passable\'s enforce function', () => {
         expect(en.noneOf).to.be.a('function');
     });
 
-    it('Should allow chaining all functions after allOf', () => {
-        const allOf = enforce().allOf({});
+    it('Should allow chaining all functions after allOf if not thrown', () => {
+        const allOf = enforce(1).allOf({largerThan: 0});
         expect(allOf.fin).to.be.a('function');
         expect(allOf.allOf).to.be.a('function');
         expect(allOf.anyOf).to.be.a('function');
         expect(allOf.noneOf).to.be.a('function');
     });
 
-    it('Should allow chaining all functions after anyOf', () => {
-        const anyOf = enforce().anyOf({});
+    it('Should throw errors on failing enforces', () => {
+        const allOf = () => enforce(1).allOf({largerThan: 2}),
+            anyOf = () => enforce(1).anyOf({smallerThan: 0}),
+            noneOf = () => enforce(1).noneOf({largerThan: 0});
+        expect(allOf).to.throw(Error);
+        expect(anyOf).to.throw(Error);
+        expect(noneOf).to.throw(Error);
+    });
+
+    it('Should allow chaining all functions after anyOf if not thrown', () => {
+        const anyOf = enforce(1).anyOf({largerThan: 0});
         expect(anyOf.fin).to.be.a('function');
         expect(anyOf.allOf).to.be.a('function');
         expect(anyOf.anyOf).to.be.a('function');
         expect(anyOf.noneOf).to.be.a('function');
     });
 
-    it('Should allow chaining all functions after anyOf', () => {
-        const noneOf = enforce().noneOf({});
+    it('Should allow chaining all functions after noneOf if not thrown', () => {
+        const noneOf = enforce(1).noneOf({largerThan: 2});
         expect(noneOf.fin).to.be.a('function');
         expect(noneOf.allOf).to.be.a('function');
         expect(noneOf.anyOf).to.be.a('function');
         expect(noneOf.noneOf).to.be.a('function');
     });
 
-    it('Should return test result after fin', () => {
-        const res1 = enforce(5).noneOf({ largerThan: 4 }).fin();
+    it('Should return test result after fin if not thrown', () => {
+        const res1 = () => enforce(5).noneOf({ largerThan: 4 }).fin();
         const res2 = enforce(5).allOf({ largerThan: 4 }).fin();
-        expect(res1).to.equal(false);
+        expect(res1).throws(Error);
         expect(res2).to.equal(true);
     });
 });
@@ -49,61 +58,61 @@ describe('Test Passable\'s enforce function', () => {
 describe('Test Enforce rules', () => {
     it('Should give back correct responses for size rules', () => {
         const res1 = enforce(5).allOf({ largerThan: 4 }).fin(),
-            res2 = enforce([]).allOf({ largerThan: 4 }).fin(),
-            res3 = enforce(5).allOf({ smallerThan: 4 }).fin(),
+            res2 = () => enforce([]).allOf({ largerThan: 4 }).fin(),
+            res3 = () => enforce(5).allOf({ smallerThan: 4 }).fin(),
             res4 = enforce('no.').allOf({ smallerThan: 4 }).fin(),
             res5 = enforce(4).allOf({ sizeEquals: 4 }).fin(),
-            res6 = enforce(4).allOf({ sizeEquals: 3 }).fin(),
+            res6 = () => enforce(4).allOf({ sizeEquals: 3 }).fin(),
             res7 = enforce(0).allOf({ isEmpty: true }).fin(),
-            res8 = enforce([]).allOf({ isEmpty: false }).fin(),
-            res9 = enforce('no').allOf({ isEmpty: true }).fin();
+            res8 = () => enforce([]).allOf({ isEmpty: false }).fin(),
+            res9 = () => enforce('no').allOf({ isEmpty: true }).fin();
 
         expect(res1).to.equal(true);
-        expect(res2).to.equal(false);
-        expect(res3).to.equal(false);
+        expect(res2).to.throw(Error);
+        expect(res3).to.throw(Error);
         expect(res4).to.equal(true);
         expect(res5).to.equal(true);
-        expect(res6).to.equal(false);
+        expect(res6).to.throw(Error);
         expect(res7).to.equal(true);
-        expect(res8).to.equal(false);
-        expect(res9).to.equal(false);
+        expect(res8).to.throw(Error);
+        expect(res9).to.throw(Error);
     });
 
     it('Should give back correct responses for lang rules', () => {
-        const res1 = enforce(5).allOf({ isArray: true }).fin(),
+        const res1 = () => enforce(5).allOf({ isArray: true }).fin(),
             res2 = enforce([]).allOf({ isArray: true }).fin(),
-            res3 = enforce([]).allOf({ isArray: false }).fin(),
-            res4 = enforce(5).allOf({ isString: true }).fin(),
+            res3 = () => enforce([]).allOf({ isArray: false }).fin(),
+            res4 = () => enforce(5).allOf({ isString: true }).fin(),
             res5 = enforce('no.').allOf({ isString: true }).fin(),
-            res6 = enforce('4').allOf({ isString: false }).fin(),
+            res6 = () => enforce('4').allOf({ isString: false }).fin(),
             res7 = enforce(4).allOf({ isNumber: true }).fin(),
-            res8 = enforce(4).allOf({ isNumber: false }).fin(),
-            res9 = enforce('4').allOf({ isNumber: true }).fin();
+            res8 = () => enforce(4).allOf({ isNumber: false }).fin(),
+            res9 = () => enforce('4').allOf({ isNumber: true }).fin();
 
-        expect(res1).to.equal(false);
+        expect(res1).to.throw(Error);
         expect(res2).to.equal(true);
-        expect(res3).to.equal(false);
-        expect(res4).to.equal(false);
+        expect(res3).to.throw(Error);
+        expect(res4).to.throw(Error);
         expect(res5).to.equal(true);
-        expect(res6).to.equal(false);
+        expect(res6).to.throw(Error);
         expect(res7).to.equal(true);
-        expect(res8).to.equal(false);
-        expect(res9).to.equal(false);
+        expect(res8).to.throw(Error);
+        expect(res9).to.throw(Error);
     });
 
     it('Should give back correct responses for content rules', () => {
         const res1 = enforce('hello').allOf({ matches: /^[a-zA-Z]{4,7}$/ }).fin(),
-            res2 = enforce('foo').allOf({ matches: /^[a-zA-Z]{4,7}$/ }).fin(),
+            res2 = () => enforce('foo').allOf({ matches: /^[a-zA-Z]{4,7}$/ }).fin(),
             res3 = enforce(44).allOf({ matches: '[0-9]' }).fin(),
             res4 = enforce(2).allOf({ inside: [1, 2, 3] }).fin(),
             res5 = enforce('or').allOf({ inside: 'Hello World!' }).fin(),
-            res6 = enforce('4').allOf({ inside: {a: 1, b: 2} }).fin();
+            res6 = () => enforce('4').allOf({ inside: {a: 1, b: 2} }).fin();
 
         expect(res1).to.equal(true);
-        expect(res2).to.equal(false);
+        expect(res2).to.throw(Error);
         expect(res3).to.equal(true);
         expect(res4).to.equal(true);
         expect(res5).to.equal(true);
-        expect(res6).to.equal(false);
+        expect(res6).to.throw(Error);
     });
 });

--- a/src/pass_runner/index.js
+++ b/src/pass_runner/index.js
@@ -6,14 +6,18 @@ function passRunner(callback) {
         return false;
     }
 
-    const res = callback();
+    try {
+        const res = callback();
 
-    if (typeof res !== 'undefined' && res !== null && res.hasOwnProperty('valid')) {
-        isValid = res.valid;
-    } else if (typeof res === 'boolean') {
-        isValid = res || false;
-    } else if (this.valid) {
-        isValid = this.valid;
+        if (typeof res !== 'undefined' && res !== null && res.hasOwnProperty('valid')) {
+            isValid = res.valid;
+        } else if (typeof res === 'boolean') {
+            isValid = res || false;
+        } else {
+            isValid = true;
+        }
+    } catch (e) {
+        isValid = false;
     }
 
     return !!isValid;

--- a/src/pass_runner/spec.js
+++ b/src/pass_runner/spec.js
@@ -11,8 +11,8 @@ const expect = chai.expect,
 
 describe('Test Pass Runner Logic', () => {
 
-    it('Should be default to false', () => {
-        expect(pr(() => undefined)).to.equal(false);
+    it('Should default to true if not thrown', () => {
+        expect(pr(() => undefined)).to.equal(true);
     });
 
     it('Should return null if no callback is given', () => {


### PR DESCRIPTION
Before this change I was detecting failures by binding each `enforce` to an empty object `{}`, and from within the `enforce` function, updating its `valid` property.
Now, instead of relying on this fake scope, `enforce` simply throws an `Error`, which is being caught by the pass-runner.

Now, unless we explicitly return a value from within the `pass` function, if no error is being thrown, passable assumes it passed, aligning with the way it seems to work in other specing libraries.